### PR TITLE
fixed names with versions, added log and dev modes

### DIFF
--- a/iam_watching/command_line.py
+++ b/iam_watching/command_line.py
@@ -23,6 +23,13 @@ def main(assigned_args: list = None) -> None:
         version=iam_watching.__version__
     )
     parser.add_argument(
+        "-l",
+        "--log_mode",
+        action="store_true",
+        default=False,
+        help="Show events in the sequence as seen by CW"
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -54,6 +61,8 @@ def main(assigned_args: list = None) -> None:
     iam_watching.USER = args.user
     iam_watching.VERBOSE = args.verbose
     iam_watching.MAX_RESULTS = args.maxresults
+    iam_watching.LOG_MODE = args.log_mode
+    iam_watching.DEV_MODE = not args.log_mode
 
     iam_watching.main()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iam_watching"
-version = "1.5.0"
+version = "1.6.0"
 description = "Realtime monitor for IAM activity for IaC projects"
 authors = [
     {name = "Dank", email = "4129589+danktec@users.noreply.github.com"}


### PR DESCRIPTION
#4 

EventNames in CW sometimes carry an api version suffix, stripping this brings them back in-line with the iam action